### PR TITLE
feat: small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ python leak_scanner.py
 ## Command Line Options
 
 - `--min-chars <number>` - Minimum character length for values to consider (default: 5)
-- `--keep-found-values` - Keep the temporary file containing gathered values instead of deleting it
+- `--keep-temp-file` - Keep the temporary file containing gathered values instead of deleting it
 - `--timeout <seconds>` - Maximum time to spend scanning filesystem for .env files (default: 0 for unlimited, set a number for time limit)
 - `--verbose, -v` - Show detailed scanning progress and debug information
 
@@ -106,7 +106,7 @@ The scanner collects potential secrets from these sources:
 - **No data transmission**: Secrets are never sent to GitGuardian or any external service
 - **Local processing**: All scanning happens locally on your machine
 - **Hash comparison**: Only SHA-256 hashes of potential secrets are compared against GitGuardian's database
-- **Temporary files**: A temporary file `gg_gathered_values` is created during scanning and automatically deleted (unless `--keep-found-values` is used)
+- **Temporary files**: A temporary file `gg_gathered_values` is created during scanning and automatically deleted (unless `--keep-temp-file` is used)
 
 ## Examples
 
@@ -123,7 +123,7 @@ Scan with longer timeout for large filesystems:
 
 Keep the temporary file for inspection:
 ```bash
-./leak_scanner.py --keep-found-values
+./leak_scanner.py --keep-temp-file
 ```
 
 Only consider longer values (reduces noise):

--- a/leak_scanner.py
+++ b/leak_scanner.py
@@ -120,7 +120,7 @@ def select_file(fpath: Path) -> str | None:
     """Return the file key prefix if this file should be processed."""
     if fpath.name == '.npmrc':
         return NPMRC_PREFIX
-    elif fpath.name.startswith('.env'):
+    elif fpath.name.startswith('.env') and not "example" in fpath.name:
         safe_path = str(fpath).replace('/', '_').replace('.', '_')
         return f"{ENV_FILE_PREFIX}{SOURCE_SEPARATOR}{safe_path}"
     return None
@@ -363,8 +363,8 @@ def find_leaks(args):
     if args.verbose:
         print()
         timeout_desc = f"{args.timeout}s" if args.timeout > 0 else "unlimited"
-        keep_desc = "yes" if args.keep_found_values else "no"
-        print(f"⚙️  Settings: min-chars={args.min_chars}, timeout={timeout_desc}, keep-found-values={keep_desc}")
+        keep_desc = "yes" if args.keep_temp_file else "no"
+        print(f"⚙️  Settings: min-chars={args.min_chars}, timeout={timeout_desc}, keep-temp-file={keep_desc}")
         print()
 
     # Display scanning progress
@@ -420,7 +420,7 @@ def find_leaks(args):
                 print("⚠️  Error checking secrets - run with --verbose for details")
     
     
-    if not args.keep_found_values:
+    if not args.keep_temp_file:
         try:
             os.remove(SECRETS_FILE_NAME)
             if args.verbose:
@@ -438,9 +438,9 @@ def parse_args():
         default=5,
     )
     parser.add_argument(
-        "--keep-found-values",
+        "--keep-temp-file",
         action="store_true",
-        help="Do not delete the file that holds found values (potentially secrets)",
+        help="Keep the temporary file containing gathered values instead of deleting it",
     )
     parser.add_argument(
         "--timeout",


### PR DESCRIPTION
- rename option keep-found-values to keep-temp-file
- ignore example .env